### PR TITLE
feat: allow config.json to fetch classifier labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ var request =
       DISCARDED_LABELS, List.of("O")
     )
   );
+
+// But also
+var request = new InferenceRequest(
+    InferenceAction.START,
+    Map.of(
+            INFERENCE_FORMAT, ONNX_BERT,
+            INFERENCE_TYPE, CLASSIFIER,
+            CLASSIFIER_MODE, TOKEN,
+            MODEL_PATH, "/path/to/your/dslim/distilbert-NER/model.onnx",
+            TOKENIZER_PATH, "/path/to/your/dslim/distilbert-NER/tokenizer.json",
+            CONFIG_JSON_PATH, "/path/to/your/dslim/distilbert-NER/config.json",
+            DISCARDED_LABELS, List.of("O")
+    )
+);
+
+//This applies also to Sequence classification
 ```
 
 > If you provide the same model at least twice (based on the configuration map), many addresses will be created but only

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <maven.compiler.release>21</maven.compiler.release>
-    <gravitee-inference.version>1.0.0</gravitee-inference.version>
-    <gravitee-inference-math-native.version>${gravitee-inference.version}</gravitee-inference-math-native.version>
+    <gravitee-inference.version>1.1.1</gravitee-inference.version>
     <properties-maven-plugin.version>1.1.0</properties-maven-plugin.version>
 
     <!-- Property used by the publication job in CI-->
@@ -76,7 +75,7 @@
     <dependency>
       <groupId>io.gravitee.inference.math.native</groupId>
       <artifactId>gravitee-inference-math-native</artifactId>
-      <version>${gravitee-inference-math-native.version}</version>
+      <version>${gravitee-inference.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/gravitee/inference/service/repository/ModelRepository.java
+++ b/src/main/java/io/gravitee/inference/service/repository/ModelRepository.java
@@ -19,6 +19,7 @@ import static io.gravitee.inference.api.Constants.*;
 import static io.gravitee.inference.api.service.InferenceFormat.ONNX_BERT;
 import static io.gravitee.inference.api.service.InferenceType.CLASSIFIER;
 import static java.lang.Thread.currentThread;
+import static java.util.Optional.ofNullable;
 
 import io.gravitee.inference.api.classifier.ClassifierMode;
 import io.gravitee.inference.api.embedding.PoolingMode;
@@ -32,7 +33,9 @@ import io.gravitee.inference.onnx.bert.classifier.OnnxBertClassifierModel;
 import io.gravitee.inference.onnx.bert.config.OnnxBertConfig;
 import io.gravitee.inference.onnx.bert.embedding.OnnxBertEmbeddingModel;
 import io.gravitee.inference.onnx.bert.resource.OnnxBertResource;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -128,7 +131,7 @@ public class ModelRepository implements Repository<Model> {
       new OnnxBertConfig(
         getResource(config),
         NativeMath.INSTANCE,
-        Map.of(CLASSIFIER_MODE, mode, CLASSIFIER_LABELS, config.get(CLASSIFIER_LABELS))
+        Map.of(CLASSIFIER_MODE, mode, CLASSIFIER_LABELS, ofNullable(config.get(CLASSIFIER_LABELS)).orElse(List.of()))
       )
     );
   }
@@ -150,7 +153,11 @@ public class ModelRepository implements Repository<Model> {
   }
 
   private static OnnxBertResource getResource(ConfigWrapper config) {
-    return new OnnxBertResource(Paths.get(config.<String>get(MODEL_PATH)), Paths.get(config.<String>get(TOKENIZER_PATH)));
+    return new OnnxBertResource(
+      Paths.get(config.<String>get(MODEL_PATH)),
+      Paths.get(config.<String>get(TOKENIZER_PATH)),
+      ofNullable(config.<String>get(CONFIG_JSON_PATH)).map(Paths::get).orElse(null)
+    );
   }
 
   // This is to access native libraries present in the classpath

--- a/src/test/java/io/gravitee/inference/service/handler/repository/ModelRepositoryTest.java
+++ b/src/test/java/io/gravitee/inference/service/handler/repository/ModelRepositoryTest.java
@@ -42,6 +42,7 @@ public class ModelRepositoryTest extends BaseDownloadModelTest {
   private static final String TOKEN_MODEL = "dslim/distilbert-NER";
   public static final String ONNX_MODEL = "/resolve/main/onnx/model.onnx";
   public static final String TOKENIZER_JSON = "/resolve/main/onnx/tokenizer.json";
+  public static final String CONFIG_JSON = "/resolve/main/config.json";
 
   private ModelRepository repository;
 
@@ -59,10 +60,10 @@ public class ModelRepositoryTest extends BaseDownloadModelTest {
             getUriIfExist(TOKEN_MODEL, ONNX_MODEL).toASCIIString().split(":")[1],
             TOKENIZER_PATH,
             getUriIfExist(TOKEN_MODEL, TOKENIZER_JSON).toASCIIString().split(":")[1],
+            CONFIG_JSON_PATH,
+            getUriIfExist(TOKEN_MODEL, CONFIG_JSON).toASCIIString().split(":")[1],
             CLASSIFIER_MODE,
-            "TOKEN",
-            CLASSIFIER_LABELS,
-            List.of("O", "B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC", "B-MISC", "I-MISC")
+            "TOKEN"
           )
         ),
         "My name is Clara and I am from Berkley, California",
@@ -80,10 +81,10 @@ public class ModelRepositoryTest extends BaseDownloadModelTest {
             getUriIfExist(SEQUENCE_MODEL, ONNX_MODEL).toASCIIString().split(":")[1],
             TOKENIZER_PATH,
             getUriIfExist(SEQUENCE_MODEL, TOKENIZER_JSON).toASCIIString().split(":")[1],
+            CONFIG_JSON_PATH,
+            getUriIfExist(SEQUENCE_MODEL, CONFIG_JSON).toASCIIString().split(":")[1],
             CLASSIFIER_MODE,
-            "SEQUENCE",
-            CLASSIFIER_LABELS,
-            List.of("Negative", "Positive")
+            "SEQUENCE"
           )
         ),
         "I am happy today!",


### PR DESCRIPTION
This PR brings the v1.1.1 of gravitee-inference to include  labels from `config.json` for classifier models
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.0-feat-add-config-json-integration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/service/gravitee-inference-service/1.1.0-feat-add-config-json-integration-SNAPSHOT/gravitee-inference-service-1.1.0-feat-add-config-json-integration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
