### PR TITLE
feat: service.inference.enabled parameter + tokenizer fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,14 +322,6 @@
     </plugin>
 
     <plugin>
-      <groupId>org.sonatype.plugins</groupId>
-      <artifactId>nexus-staging-maven-plugin</artifactId>
-      <version>${nexus-staging-maven-plugin.version}</version>
-      <configuration>
-        <skipRemoteStaging>true</skipRemoteStaging>
-      </configuration>
-    </plugin>
-    <plugin>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-gpg-plugin</artifactId>
       <version>${maven-gpg-plugin.version}</version>

--- a/src/main/java/io/gravitee/inference/service/handler/ModelHandler.java
+++ b/src/main/java/io/gravitee/inference/service/handler/ModelHandler.java
@@ -17,15 +17,18 @@ package io.gravitee.inference.service.handler;
 
 import static io.gravitee.inference.api.Constants.*;
 
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
 import io.gravitee.inference.api.service.InferenceRequest;
 import io.gravitee.inference.api.utils.ConfigWrapper;
 import io.gravitee.inference.service.repository.ModelRepository;
+import io.gravitee.inference.service.utils.TokenizerUtils;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.eventbus.Message;
+import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,6 +58,7 @@ public class ModelHandler implements Handler<Message<Buffer>> {
         .toObservable()
         .subscribe(this::handle, throwable -> LOGGER.error("Inference service handler failed", throwable));
     this.repository = repository;
+    TokenizerUtils.loadTokenizerLibrary();
   }
 
   @Override

--- a/src/main/java/io/gravitee/inference/service/repository/ModelRepository.java
+++ b/src/main/java/io/gravitee/inference/service/repository/ModelRepository.java
@@ -147,7 +147,8 @@ public class ModelRepository implements Repository<Model> {
           poolingMode,
           MAX_SEQUENCE_LENGTH,
           config.get(MAX_SEQUENCE_LENGTH, MAX_SEQUENCE_LENGTH_DEFAULT_VALUE)
-        )
+        ),
+        Map.of(PADDING, config.get(PADDING, "false"))
       )
     );
   }

--- a/src/main/java/io/gravitee/inference/service/utils/TokenizerUtils.java
+++ b/src/main/java/io/gravitee/inference/service/utils/TokenizerUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.inference.service.utils;
+
+import ai.djl.huggingface.tokenizers.jni.LibUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class TokenizerUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(TokenizerUtils.class);
+
+  public static void loadTokenizerLibrary() {
+    logger.debug("Loading tokenizer native libraries");
+    LibUtils.checkStatus();
+    logger.debug("Tokenizer native libraries loaded");
+  }
+}

--- a/src/test/java/io/gravitee/inference/service/handler/InferenceServiceTest.java
+++ b/src/test/java/io/gravitee/inference/service/handler/InferenceServiceTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.inference.service.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.gravitee.inference.service.InferenceService;
+import io.vertx.rxjava3.core.Vertx;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class InferenceServiceTest {
+
+  @Test
+  public void must_not_load_inference_service() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    var inferenceService = new InferenceService(vertx, false);
+    inferenceService.doStart();
+
+    assertFalse(inferenceService.enabled());
+    assertNull(inferenceService.crudHandler());
+
+    inferenceService.doStop();
+    vertx.close();
+  }
+
+  @Test
+  public void must_load_inference_service() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    var inferenceService = new InferenceService(vertx, true);
+    inferenceService.doStart();
+
+    assertTrue(inferenceService.enabled());
+    assertNotNull(inferenceService.crudHandler());
+
+    inferenceService.doStop();
+    vertx.close();
+  }
+}

--- a/src/test/java/io/gravitee/inference/service/handler/ModelHandlerTest.java
+++ b/src/test/java/io/gravitee/inference/service/handler/ModelHandlerTest.java
@@ -31,6 +31,7 @@ import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.eventbus.EventBus;
 import io.vertx.rxjava3.core.eventbus.Message;
 import io.vertx.rxjava3.core.eventbus.MessageConsumer;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -66,7 +67,7 @@ public class ModelHandlerTest {
   private ModelHandler modelHandler;
 
   @BeforeEach
-  public void setUp() {
+  public void setUp() throws IOException {
     when(vertx.eventBus()).thenReturn(eventBus);
     when(eventBus.<Buffer>consumer(anyString())).thenReturn(messageConsumer);
     when(messageConsumer.toObservable()).thenReturn(Observable.just(message));


### PR DESCRIPTION
This PR introduces `service.inference.enabled=false` not to bloat the gateway if AI models aren't used.
It also loads the tokenizer lib on start-up.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-fix-service-enabled-tokenizer-load-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/service/gravitee-inference-service/1.2.0-fix-service-enabled-tokenizer-load-SNAPSHOT/gravitee-inference-service-1.2.0-fix-service-enabled-tokenizer-load-SNAPSHOT.zip)
  <!-- Version placeholder end -->
