### PR TITLE
feat: download and load model asynchronously from address creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 .idea
 .java-version
+models/

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <!-- Property used by the publication job in CI-->
     <publish-folder-path>plugins/services</publish-folder-path>
-    <gravitee-reactive-webclient-huggingface.version>1.0.0-MLAI-230-SNAPSHOT</gravitee-reactive-webclient-huggingface.version>
+    <gravitee-reactive-webclient-huggingface.version>1.1.0</gravitee-reactive-webclient-huggingface.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 
     <!-- Property used by the publication job in CI-->
     <publish-folder-path>plugins/services</publish-folder-path>
+    <gravitee-reactive-webclient-huggingface.version>1.0.0-MLAI-230-SNAPSHOT</gravitee-reactive-webclient-huggingface.version>
   </properties>
 
   <dependencyManagement>
@@ -76,6 +77,12 @@
       <groupId>io.gravitee.inference.math.native</groupId>
       <artifactId>gravitee-inference-math-native</artifactId>
       <version>${gravitee-inference.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.gravitee.reactive.webclient</groupId>
+      <artifactId>gravitee-reactive-webclient-huggingface</artifactId>
+      <version>${gravitee-reactive-webclient-huggingface.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/gravitee/inference/service/InferenceService.java
+++ b/src/main/java/io/gravitee/inference/service/InferenceService.java
@@ -29,6 +29,7 @@ import io.vertx.rxjava3.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
@@ -40,6 +41,7 @@ public class InferenceService extends AbstractService<InferenceService> {
 
   private final Logger LOGGER = LoggerFactory.getLogger(InferenceService.class);
   private final Vertx vertx;
+  private final String modelPath;
 
   private ModelHandler crudHandler;
 
@@ -47,8 +49,12 @@ public class InferenceService extends AbstractService<InferenceService> {
   private Disposable consumer;
 
   @Autowired
-  public InferenceService(Vertx vertx) {
+  public InferenceService(
+    Vertx vertx,
+    @Value("${inference.path:#{systemProperties['gravitee.home']}/models}") String modelPath
+  ) {
     this.vertx = vertx;
+    this.modelPath = modelPath;
   }
 
   @Override
@@ -60,7 +66,7 @@ public class InferenceService extends AbstractService<InferenceService> {
   protected void doStart() throws Exception {
     LOGGER.debug("Starting Inference service");
     super.doStart();
-    crudHandler = new ModelHandler(vertx, new ModelRepository(), new HuggingFaceDownloader(vertx));
+    crudHandler = new ModelHandler(vertx, modelPath, new ModelRepository(), new HuggingFaceDownloader(vertx));
     consumer =
       vertx
         .eventBus()

--- a/src/main/java/io/gravitee/inference/service/handler/ModelHandler.java
+++ b/src/main/java/io/gravitee/inference/service/handler/ModelHandler.java
@@ -18,7 +18,6 @@ package io.gravitee.inference.service.handler;
 import static io.gravitee.inference.api.Constants.*;
 import static java.util.Optional.ofNullable;
 
-import io.gravitee.inference.api.Constants;
 import io.gravitee.inference.api.service.InferenceRequest;
 import io.gravitee.inference.api.utils.ConfigWrapper;
 import io.gravitee.inference.service.repository.ModelRepository;
@@ -26,7 +25,6 @@ import io.gravitee.reactive.webclient.api.FetchModelConfig;
 import io.gravitee.reactive.webclient.api.ModelFetcher;
 import io.gravitee.reactive.webclient.api.ModelFile;
 import io.gravitee.reactive.webclient.api.ModelFileType;
-import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
@@ -48,20 +46,19 @@ import org.slf4j.LoggerFactory;
  */
 public class ModelHandler implements Handler<Message<Buffer>> {
 
-  private static final String GRAVITEE_HOME = "gravitee.home";
-  private static final String GRAVITEE_HOME_PATH = System.getProperty(GRAVITEE_HOME);
-  private static final String MODEL_NAME = "modelName";
+  public static final String MODEL_NAME = "modelName";
 
   private final Logger log = LoggerFactory.getLogger(ModelHandler.class);
 
   private final Vertx vertx;
+  private final String modelPath;
   private final ModelRepository repository;
-
   private final Map<String, InferenceHandler> inferenceHandlers = new ConcurrentHashMap<>();
   private final ModelFetcher fetcher;
 
-  public ModelHandler(Vertx vertx, ModelRepository repository, ModelFetcher fetcher) {
+  public ModelHandler(Vertx vertx, String modelPath, ModelRepository repository, ModelFetcher fetcher) {
     this.vertx = vertx;
+    this.modelPath = modelPath;
     this.repository = repository;
     this.fetcher = fetcher;
   }
@@ -137,7 +134,7 @@ public class ModelHandler implements Handler<Message<Buffer>> {
   }
 
   private Path getFileDirectory(String modelName) {
-    Path directory = Path.of(GRAVITEE_HOME_PATH + "/models/" + modelName);
+    Path directory = Path.of(this.modelPath + "/" + modelName);
     try {
       return Files.createDirectories(directory);
     } catch (FileAlreadyExistsException faee) {

--- a/src/main/java/io/gravitee/inference/service/repository/Repository.java
+++ b/src/main/java/io/gravitee/inference/service/repository/Repository.java
@@ -16,13 +16,14 @@
 package io.gravitee.inference.service.repository;
 
 import io.gravitee.inference.api.service.InferenceRequest;
+import java.util.Map;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface Repository<T> {
-  T add(InferenceRequest request);
+  T add(Map<String, Object> config);
 
   void remove(Model model);
 }

--- a/src/test/java/io/gravitee/inference/service/handler/InferenceHandlerTest.java
+++ b/src/test/java/io/gravitee/inference/service/handler/InferenceHandlerTest.java
@@ -81,7 +81,8 @@ public class InferenceHandlerTest {
     when(observable.subscribeOn(any())).thenReturn(observable);
     when(observable.observeOn(any())).thenReturn(Observable.just(message));
 
-    inferenceHandler = new InferenceHandler("test-address", new Model(0, model), vertx);
+    inferenceHandler = new InferenceHandler("test-address", vertx);
+    inferenceHandler.setModel(new Model(0, model));
   }
 
   @Test

--- a/src/test/java/io/gravitee/inference/service/handler/ModelHandlerTest.java
+++ b/src/test/java/io/gravitee/inference/service/handler/ModelHandlerTest.java
@@ -17,6 +17,8 @@ package io.gravitee.inference.service.handler;
 
 import static io.gravitee.inference.api.Constants.MODEL_ADDRESS_KEY;
 import static io.gravitee.inference.api.service.InferenceAction.*;
+import static io.reactivex.rxjava3.core.Observable.fromRunnable;
+import static io.reactivex.rxjava3.core.Observable.timer;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.inference.api.Constants;
@@ -24,7 +26,11 @@ import io.gravitee.inference.api.InferenceModel;
 import io.gravitee.inference.api.service.InferenceRequest;
 import io.gravitee.inference.service.repository.Model;
 import io.gravitee.inference.service.repository.ModelRepository;
+import io.gravitee.reactive.webclient.api.ModelFetcher;
+import io.gravitee.reactive.webclient.api.ModelFile;
+import io.gravitee.reactive.webclient.api.ModelFileType;
 import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import io.vertx.rxjava3.core.Vertx;
@@ -33,6 +39,7 @@ import io.vertx.rxjava3.core.eventbus.Message;
 import io.vertx.rxjava3.core.eventbus.MessageConsumer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,10 +56,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class ModelHandlerTest {
 
   @Mock
+  private EventBus eventBus;
+
+  @Mock
   private Vertx vertx;
 
   @Mock
-  private EventBus eventBus;
+  private ModelFetcher fetcher;
 
   @Mock
   private ModelRepository repository;
@@ -64,31 +74,36 @@ public class ModelHandlerTest {
   private Message<Buffer> message;
 
   private ModelHandler modelHandler;
+
   private io.vertx.core.Vertx delegate;
 
   @BeforeEach
   public void setUp() {
     delegate = io.vertx.core.Vertx.vertx();
-    when(vertx.getDelegate()).thenReturn(delegate);
-    when(vertx.eventBus()).thenReturn(eventBus);
-    when(eventBus.<Buffer>consumer(anyString())).thenReturn(messageConsumer);
-    Observable observable = mock(Observable.class);
-    when(messageConsumer.toObservable()).thenReturn(observable);
-    when(observable.subscribeOn(any())).thenReturn(observable);
-    when(observable.observeOn(any())).thenReturn(Observable.just(message));
+    lenient().when(vertx.getDelegate()).thenReturn(delegate);
+    lenient().when(vertx.eventBus()).thenReturn(eventBus);
 
-    modelHandler = new ModelHandler(vertx, repository);
-  }
+    lenient().when(eventBus.<Buffer>consumer(anyString())).thenReturn(messageConsumer);
+    Observable<Message<Buffer>> observable = Observable.just(message);
 
-  @Test
-  public void must_handle_repository_model_start() {
-    InferenceRequest request = new InferenceRequest(START, new HashMap<>());
-    when(message.body()).thenReturn(Json.encodeToBuffer(request));
-    when(repository.add(request)).thenReturn(new Model(0, mock(InferenceModel.class)));
+    lenient().when(messageConsumer.toObservable()).thenReturn(observable);
+    lenient().when(message.body()).thenReturn(Buffer.buffer("some_address"));
+    lenient()
+      .when(fetcher.fetchModel(any()))
+      .thenReturn(
+        Single.just(
+          Map.of(
+            ModelFileType.CONFIG,
+            "/path/to/config.json",
+            ModelFileType.TOKENIZER,
+            "/path/to/tokenizer.json",
+            ModelFileType.MODEL,
+            "/path/to/model.json"
+          )
+        )
+      );
 
-    modelHandler.handle(message);
-
-    verify(message, times(1)).reply(any());
+    modelHandler = new ModelHandler(vertx, repository, fetcher);
   }
 
   @Test
@@ -96,20 +111,29 @@ public class ModelHandlerTest {
     InferenceRequest request = new InferenceRequest(START, new HashMap<>());
     when(message.body()).thenReturn(Json.encodeToBuffer(request));
     Model model = new Model(0, mock(InferenceModel.class));
-    when(repository.add(request)).thenReturn(model);
+    when(repository.add(any())).thenReturn(model);
 
-    modelHandler.handle(message);
-
-    verify(message, times(1)).reply(any());
+    fromRunnable(() -> modelHandler.handle(message))
+      .flatMap(__ -> timer(2, TimeUnit.SECONDS))
+      .test()
+      .awaitDone(3, TimeUnit.SECONDS)
+      .assertComplete()
+      .assertNoErrors();
 
     ArgumentCaptor<Buffer> captor = ArgumentCaptor.forClass(Buffer.class);
-    verify(message).reply(captor.capture());
+    verify(message, times(1)).reply(captor.capture());
     Buffer addressBuffer = captor.getValue();
 
     doNothing().when(repository).remove(eq(model));
     when(message.body())
       .thenReturn(Json.encodeToBuffer(new InferenceRequest(STOP, Map.of(MODEL_ADDRESS_KEY, addressBuffer.toString()))));
-    modelHandler.handle(message);
+
+    fromRunnable(() -> modelHandler.handle(message))
+      .flatMap(__ -> timer(2, TimeUnit.SECONDS))
+      .test()
+      .awaitDone(3, TimeUnit.SECONDS)
+      .assertComplete()
+      .assertNoErrors();
 
     verify(message, times(2)).reply(any());
   }

--- a/src/test/java/io/gravitee/inference/service/handler/ModelHandlerTest.java
+++ b/src/test/java/io/gravitee/inference/service/handler/ModelHandlerTest.java
@@ -21,13 +21,11 @@ import static io.reactivex.rxjava3.core.Observable.fromRunnable;
 import static io.reactivex.rxjava3.core.Observable.timer;
 import static org.mockito.Mockito.*;
 
-import io.gravitee.inference.api.Constants;
 import io.gravitee.inference.api.InferenceModel;
 import io.gravitee.inference.api.service.InferenceRequest;
 import io.gravitee.inference.service.repository.Model;
 import io.gravitee.inference.service.repository.ModelRepository;
 import io.gravitee.reactive.webclient.api.ModelFetcher;
-import io.gravitee.reactive.webclient.api.ModelFile;
 import io.gravitee.reactive.webclient.api.ModelFileType;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
@@ -40,6 +38,7 @@ import io.vertx.rxjava3.core.eventbus.MessageConsumer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.assertj.core.util.Files;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -103,12 +102,14 @@ public class ModelHandlerTest {
         )
       );
 
-    modelHandler = new ModelHandler(vertx, repository, fetcher);
+    modelHandler = new ModelHandler(vertx, Files.newTemporaryFolder().toString(), repository, fetcher);
   }
 
   @Test
   public void must_handle_create_model_action() {
-    InferenceRequest request = new InferenceRequest(START, new HashMap<>());
+    HashMap<String, Object> payload = new HashMap<>();
+    payload.put("modelName", "models/");
+    InferenceRequest request = new InferenceRequest(START, payload);
     when(message.body()).thenReturn(Json.encodeToBuffer(request));
     Model model = new Model(0, mock(InferenceModel.class));
     when(repository.add(any())).thenReturn(model);

--- a/src/test/java/io/gravitee/inference/service/handler/repository/ModelRepositoryTest.java
+++ b/src/test/java/io/gravitee/inference/service/handler/repository/ModelRepositoryTest.java
@@ -124,7 +124,7 @@ public class ModelRepositoryTest extends BaseDownloadModelTest {
   @ParameterizedTest
   @MethodSource("params_that_must_build_model")
   void must_setup_model_lifecycle(InferenceRequest request, String input, Class<?> expectedClass) {
-    Model model = repository.add(request);
+    Model model = repository.add(request.payload());
     assertNotNull(model);
 
     assertInstanceOf(expectedClass, model.inferenceModel());
@@ -133,7 +133,7 @@ public class ModelRepositoryTest extends BaseDownloadModelTest {
     assertEquals(1, repository.getModelsSize());
     assertEquals(1, repository.getModelUsage(model.key()));
 
-    repository.add(request);
+    repository.add(request.payload());
 
     assertEquals(1, repository.getModelsSize());
     assertEquals(2, repository.getModelUsage(model.key()));


### PR DESCRIPTION
Issue

https://gravitee.atlassian.net/browse/MLAI-230

Description

This PR allows the inferenceService to download and load the model asynchronously from the address creation

Additional context

related PR: https://github.com/gravitee-io/gravitee-resource-ai-model-api/pull/8
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-MLAI-230-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/service/gravitee-inference-service/1.2.0-MLAI-230-SNAPSHOT/gravitee-inference-service-1.2.0-MLAI-230-SNAPSHOT.zip)
  <!-- Version placeholder end -->
