### PR TITLE
fix: handler key instead of hashcode

### DIFF
--- a/src/main/java/io/gravitee/inference/service/handler/DelegatingInferenceHandler.java
+++ b/src/main/java/io/gravitee/inference/service/handler/DelegatingInferenceHandler.java
@@ -75,4 +75,9 @@ public class DelegatingInferenceHandler implements InferenceHandler {
       LOGGER.debug("DelegatingInferenceHandler handler {} stopped", address);
     }
   }
+
+  @Override
+  public int key() {
+    return this.hashCode();
+  }
 }

--- a/src/main/java/io/gravitee/inference/service/handler/InferenceHandler.java
+++ b/src/main/java/io/gravitee/inference/service/handler/InferenceHandler.java
@@ -25,4 +25,6 @@ public interface InferenceHandler extends Handler<Message<Buffer>> {
   }
 
   void close();
+
+  int key();
 }

--- a/src/main/java/io/gravitee/inference/service/handler/LocalInferenceHandler.java
+++ b/src/main/java/io/gravitee/inference/service/handler/LocalInferenceHandler.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 public class LocalInferenceHandler implements InferenceHandler {
 
-  private final int hashCode;
+  private final int key;
   private final LocalModelFactory localModelFactory;
 
   private OnnxInference<?, ?, ?> model;
@@ -40,7 +40,7 @@ public class LocalInferenceHandler implements InferenceHandler {
   public LocalInferenceHandler(Map<String, Object> payload, LocalModelFactory modelFactory) {
     this.payload = payload;
     this.localModelFactory = modelFactory;
-    this.hashCode = payload.hashCode();
+    this.key = payload.hashCode();
   }
 
   @Override
@@ -60,15 +60,15 @@ public class LocalInferenceHandler implements InferenceHandler {
     }
   }
 
-  @Override
-  public int hashCode() {
-    return hashCode;
-  }
-
   public void close() {
     if (model != null) {
       model.close();
     }
+  }
+
+  @Override
+  public int key() {
+    return key;
   }
 
   @Override

--- a/src/main/java/io/gravitee/inference/service/handler/RemoteInferenceHandler.java
+++ b/src/main/java/io/gravitee/inference/service/handler/RemoteInferenceHandler.java
@@ -30,12 +30,14 @@ public class RemoteInferenceHandler implements InferenceHandler {
 
   private final RemoteModelFactory modelFactory;
   private final Map<String, Object> payload;
+  private final int key;
 
   private RestInference<?, ?, ?> model;
 
   public RemoteInferenceHandler(Map<String, Object> payload, RemoteModelFactory modelFactory) {
     this.modelFactory = modelFactory;
     this.payload = payload;
+    this.key = payload.hashCode();
   }
 
   @Override
@@ -65,6 +67,11 @@ public class RemoteInferenceHandler implements InferenceHandler {
     if (model != null) {
       model.close();
     }
+  }
+
+  @Override
+  public int key() {
+    return key;
   }
 
   public void loadModel() {

--- a/src/main/java/io/gravitee/inference/service/repository/HandlerRepository.java
+++ b/src/main/java/io/gravitee/inference/service/repository/HandlerRepository.java
@@ -36,7 +36,7 @@ public class HandlerRepository implements Repository<InferenceHandler> {
   @Override
   public InferenceHandler add(InferenceHandler handler) {
     models.compute(
-      handler.hashCode(),
+      handler.key(),
       (k, v) -> {
         if (v != null) {
           LOGGER.debug("Model already exists, returning existing model");
@@ -60,7 +60,7 @@ public class HandlerRepository implements Repository<InferenceHandler> {
       }
     );
 
-    return models.get(handler.hashCode());
+    return models.get(handler.key());
   }
 
   public int getModelsSize() {
@@ -74,7 +74,7 @@ public class HandlerRepository implements Repository<InferenceHandler> {
   @Override
   public void remove(InferenceHandler handler) {
     counters.computeIfPresent(
-      handler.hashCode(),
+      handler.key(),
       (k, v) -> {
         var counter = v.decrementAndGet();
         if (counter == 0) {

--- a/src/test/java/io/gravitee/inference/service/repository/ModelRepositoryTest.java
+++ b/src/test/java/io/gravitee/inference/service/repository/ModelRepositoryTest.java
@@ -125,21 +125,21 @@ public class ModelRepositoryTest {
     assertNotNull(model);
 
     assertEquals(1, repository.getModelsSize());
-    assertEquals(1, repository.getModelUsage(model.hashCode()));
+    assertEquals(1, repository.getModelUsage(model.key()));
 
     repository.add(handler);
 
     assertEquals(1, repository.getModelsSize());
-    assertEquals(2, repository.getModelUsage(model.hashCode()));
+    assertEquals(2, repository.getModelUsage(model.key()));
 
     repository.remove(handler);
 
     assertEquals(1, repository.getModelsSize());
-    assertEquals(1, repository.getModelUsage(model.hashCode()));
+    assertEquals(1, repository.getModelUsage(model.key()));
 
     repository.remove(model);
 
     assertEquals(0, repository.getModelsSize());
-    assertEquals(0, repository.getModelUsage(model.hashCode()));
+    assertEquals(0, repository.getModelUsage(model.key()));
   }
 }


### PR DESCRIPTION
This PR handles a "key" based on the payload instead of relying on hashcode.
This forces to implement the key the HandlerRepository will use in case we bring new model handlers

Also, RestInference wasn't implementing the key which will lead to duplicated handlers
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.2-fix-key-handler-for-inference-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/service/gravitee-inference-service/1.3.2-fix-key-handler-for-inference-SNAPSHOT/gravitee-inference-service-1.3.2-fix-key-handler-for-inference-SNAPSHOT.zip)
  <!-- Version placeholder end -->
