### PR TITLE
feat: migrate to Vert.x 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@5.1.0
+  gravitee: gravitee-io/gravitee@5.8.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>23.5.0</version>
+        <version>24.0.1</version>
     </parent>
 
     <groupId>io.gravitee.inference.service</groupId>
@@ -34,17 +34,19 @@
     <url>https://gravitee.io</url>
 
     <properties>
-        <gravitee-bom.version>8.3.47</gravitee-bom.version>
+        <gravitee-bom.version>9.0.0-alpha.4</gravitee-bom.version>
         <gravitee-common.version>4.8.0</gravitee-common.version>
-        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <gravitee-inference.version>2.0.0-beta.2</gravitee-inference.version>
+        <gravitee-reactive-webclient-huggingface.version>2.0.0-alpha.1</gravitee-reactive-webclient-huggingface.version>
+
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-        <gravitee-inference.version>1.5.1</gravitee-inference.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+
+        <gravitee.archrules.skip>true</gravitee.archrules.skip>
 
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>plugins/services</publish-folder-path>
-        <gravitee-reactive-webclient-huggingface.version>1.1.0</gravitee-reactive-webclient-huggingface.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
BREAKING CHANGE: upgrade to Vert.x 5
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-update-vertx5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/service/gravitee-inference-service/2.0.0-update-vertx5-SNAPSHOT/gravitee-inference-service-2.0.0-update-vertx5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
