### PR TITLE
fix: bump huggignface client to avoid some network calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@5.8.0
+  gravitee: gravitee-io/gravitee@5.10.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>9.0.0-alpha.4</gravitee-bom.version>
         <gravitee-common.version>4.8.0</gravitee-common.version>
         <gravitee-inference.version>2.0.0-beta.2</gravitee-inference.version>
-        <gravitee-reactive-webclient-huggingface.version>2.0.0-alpha.1</gravitee-reactive-webclient-huggingface.version>
+        <gravitee-reactive-webclient-huggingface.version>2.0.0-alpha.2</gravitee-reactive-webclient-huggingface.version>
 
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14371
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-mba-apim-14371-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/service/gravitee-inference-service/2.0.0-mba-apim-14371-SNAPSHOT/gravitee-inference-service-2.0.0-mba-apim-14371-SNAPSHOT.zip)
  <!-- Version placeholder end -->
