### PR TITLE
fix: bump huggignface client to avoid some network calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@5.1.0
+  gravitee: gravitee-io/gravitee@5.10.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -36,15 +36,15 @@
     <properties>
         <gravitee-bom.version>8.3.47</gravitee-bom.version>
         <gravitee-common.version>4.8.0</gravitee-common.version>
-        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <gravitee-inference.version>1.5.1</gravitee-inference.version>
+        <gravitee-reactive-webclient-huggingface.version>1.1.1</gravitee-reactive-webclient-huggingface.version>
+
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
 
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>plugins/services</publish-folder-path>
-        <gravitee-reactive-webclient-huggingface.version>1.1.0</gravitee-reactive-webclient-huggingface.version>
     </properties>
 
     <dependencyManagement>

--- a/src/test/resources/docker-java.properties
+++ b/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14371
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.2-mba-apim-14371-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/service/gravitee-inference-service/1.4.2-mba-apim-14371-master-SNAPSHOT/gravitee-inference-service-1.4.2-mba-apim-14371-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
