### PR TITLE
merge alpha into main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     <url>https://gravitee.io</url>
 
     <properties>
-        <gravitee-bom.version>9.0.0-alpha.4</gravitee-bom.version>
+        <gravitee-bom.version>9.0.0</gravitee-bom.version>
         <gravitee-common.version>4.8.0</gravitee-common.version>
-        <gravitee-inference.version>2.0.0-beta.2</gravitee-inference.version>
-        <gravitee-reactive-webclient-huggingface.version>2.0.0-alpha.2</gravitee-reactive-webclient-huggingface.version>
+        <gravitee-inference.version>2.0.0</gravitee-inference.version>
+        <gravitee-reactive-webclient-huggingface.version>2.0.0</gravitee-reactive-webclient-huggingface.version>
 
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
@@ -190,7 +190,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>9.0.0-alpha.4</gravitee-bom.version>
         <gravitee-common.version>4.8.0</gravitee-common.version>
         <gravitee-inference.version>2.0.0-beta.2</gravitee-inference.version>
-        <gravitee-reactive-webclient-huggingface.version>2.0.0-alpha.1</gravitee-reactive-webclient-huggingface.version>
+        <gravitee-reactive-webclient-huggingface.version>2.0.0-alpha.2</gravitee-reactive-webclient-huggingface.version>
 
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>23.5.0</version>
+        <version>24.0.1</version>
     </parent>
 
     <groupId>io.gravitee.inference.service</groupId>
@@ -34,14 +34,16 @@
     <url>https://gravitee.io</url>
 
     <properties>
-        <gravitee-bom.version>8.3.47</gravitee-bom.version>
+        <gravitee-bom.version>9.0.0-alpha.4</gravitee-bom.version>
         <gravitee-common.version>4.8.0</gravitee-common.version>
-        <gravitee-inference.version>1.5.1</gravitee-inference.version>
-        <gravitee-reactive-webclient-huggingface.version>1.1.1</gravitee-reactive-webclient-huggingface.version>
+        <gravitee-inference.version>2.0.0-beta.2</gravitee-inference.version>
+        <gravitee-reactive-webclient-huggingface.version>2.0.0-alpha.1</gravitee-reactive-webclient-huggingface.version>
 
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+
+        <gravitee.archrules.skip>true</gravitee.archrules.skip>
 
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>plugins/services</publish-folder-path>


### PR DESCRIPTION
BREAKING CHANGE: upgrade to Vert.x 5
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-merge-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/inference/service/gravitee-inference-service/2.0.0-merge-alpha-SNAPSHOT/gravitee-inference-service-2.0.0-merge-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
